### PR TITLE
feat: Implement Kubernetes web installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,105 @@
-# Docker-Kubernetes
-Create examples using Dockerfiles, docker-compose setups, or Kubernetes cluster deployments.
+# Kubernetes Web Installer
+
+## Description
+Kubernetes Web Installer is a Flask-based web application that provides a user interface to automate the installation of Kubernetes on a set of servers (one master, multiple workers) via SSH. It executes pre-defined shell scripts on the target machines to set up the cluster.
+
+## Features
+*   Web-based interface for providing server connection details (IPs, usernames, passwords).
+*   Automated Kubernetes installation on a designated master node.
+*   Automated Kubernetes installation on worker nodes and joining them to the master node's cluster.
+*   Real-time feedback of the installation process displayed in the web UI.
+*   Scripts for setting up `containerd`, `kubelet`, `kubeadm`, and `kubectl`.
+*   Automatic installation of Flannel CNI on the master node.
+
+## Prerequisites for the Machine Running the Flask App
+*   Python 3.7+
+*   `pip` (Python package installer)
+*   Git (for cloning the repository)
+
+## Prerequisites for the Target Servers (Master and Workers)
+*   **Operating System:** Debian-based Linux distribution (e.g., Ubuntu 18.04, 20.04, 22.04). The scripts use `apt-get`.
+*   **SSH Access:** Password-based SSH must be enabled.
+*   **User Account:** An existing user account with `sudo` privileges is required. The application will use these credentials to connect and execute installation commands.
+*   **Internet Access:** Target servers must have internet access to download Kubernetes packages and container images.
+*   **Swap Disabled:** Kubernetes requires swap to be disabled. The installation scripts attempt to disable swap, but it's recommended to ensure it's off or can be turned off.
+*   **Unique Hostnames:** (Recommended) Each node should have a unique hostname.
+*   **Network Connectivity:** All nodes should be reachable from each other over the network. Firewalls might need adjustment for Kubernetes components (see Kubernetes documentation for port requirements).
+*   **Resources:** Sufficient CPU, RAM, and disk space as per Kubernetes requirements for your cluster size.
+
+## Setup and Installation (for the Flask App)
+
+1.  **Clone the repository (if you haven't already):**
+    ```bash
+    # git clone <repository_url>
+    # cd <repository_directory_name>
+    ```
+    (The application is expected to be in a directory, e.g., `k8s_installer_app_root/k8s_installer_app`)
+
+2.  **Navigate to the application's root directory.** This is the directory containing `requirements.txt` and the `k8s_installer_app` subdirectory.
+
+3.  **Create and activate a Python virtual environment:**
+    ```bash
+    python3 -m venv venv
+    source venv/bin/activate
+    ```
+    (On Windows, use `venv\Scripts\activate`)
+
+4.  **Install dependencies:**
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+5.  **Run the application:**
+    The application is started by running the `app.py` file located inside the `k8s_installer_app` subdirectory.
+    ```bash
+    python k8s_installer_app/app.py
+    ```
+    This will start the Flask development server.
+
+6.  **Access the application:**
+    Open your web browser and go to `http://<your-machine-ip>:5000` or `http://127.0.0.1:5000` if running locally (where `<your-machine-ip>` is the IP of the machine running the Flask app).
+
+## How to Use
+1.  Navigate to the web application in your browser.
+2.  Carefully read the **Security Warnings** displayed on the page.
+3.  Under "Master Node Configuration":
+    *   Enter the IP address of your designated master node.
+    *   Enter the username for SSH connection to the master node.
+    *   Enter the password for the specified username on the master node.
+4.  Under "Worker Nodes Configuration":
+    *   Enter a comma-separated list of IP addresses for your worker nodes (e.g., `192.168.1.101,192.168.1.102`). Leave blank if you are setting up a single-node cluster or will add workers manually later.
+    *   Enter the username for SSH connection to all worker nodes.
+    *   Enter the password for the specified username on all worker nodes.
+5.  Click the "Install Kubernetes" button.
+6.  Monitor the installation progress in the "Installation Status" section that appears on the page. This section will show logs and results from the master and worker node setup processes.
+
+## Important Security Considerations
+
+*   **Experimental Tool:** **This tool is for experimental and educational purposes only. It is NOT recommended for production environments.** Use in a secure, isolated lab environment.
+*   **Password-Based SSH:** This application uses password-based SSH authentication, which is inherently less secure than key-based authentication. Passwords are submitted through the web form and used by the backend to connect to your servers.
+*   **Sudo Privileges:** The provided credentials must have `sudo` privileges on the target servers as the installation scripts require root access to install packages, modify system configurations, and initialize the Kubernetes cluster.
+*   **Plain HTTP:** The Flask development server runs on HTTP by default, meaning all form data (including credentials) is transmitted unencrypted between your browser and the application server. **Do NOT use this tool over an untrusted network or expose the application server to the internet.**
+*   **No Input Sanitization Beyond Defaults:** While standard Flask/Jinja defenses against common web vulnerabilities (like XSS) are generally active, the application's primary focus is not on robust input sanitization for all fields against all possible attack vectors. Be mindful of the data you enter.
+*   **Review Scripts:** It is **highly recommended** to review the `k8s_installer_app/scripts/master_install.sh` and `k8s_installer_app/scripts/worker_install.sh` scripts thoroughly before running this application against any server to understand the commands that will be executed.
+*   **Data Handling:** User credentials are processed in memory by the Flask application to establish SSH connections and are not explicitly stored by this application. However, ensure the environment where the Flask app runs is secure.
+
+## Troubleshooting
+*   **SSH Connection Failures:**
+    *   Verify IP addresses, usernames, and passwords.
+    *   Ensure the SSH server is running on target machines (`sudo systemctl status ssh`).
+    *   Check if password authentication is enabled in `/etc/ssh/sshd_config` (`PasswordAuthentication yes`) on target nodes.
+    *   Test SSH connection manually from the machine running the Flask app: `ssh user@host_ip`.
+    *   Check network connectivity and firewalls (e.g., `ufw status` on targets).
+*   **Script Execution Failures:**
+    *   Carefully examine the `stdout` and `stderr` output provided in the "Installation Status" section in the UI. This often contains specific error messages from the scripts.
+    *   Ensure all prerequisites for target servers are met (OS, internet access, sudo rights).
+    *   If a script fails midway, the target machine might be in an inconsistent state. Manual cleanup or re-imaging might be necessary.
+*   **`kubeadm init` or `kubeadm join` issues:**
+    *   Check `/var/log/syslog` or use `journalctl -xe` on the target nodes for detailed logs from `kubelet` or `kubeadm`.
+    *   Ensure the Pod Network CIDR (e.g., `10.244.0.0/16` for Flannel) does not conflict with your existing network.
+*   **Python/Flask App Issues:**
+    *   Ensure all dependencies in `requirements.txt` are installed in your virtual environment.
+    *   Check the Flask development server console output for any Python errors.
+
+## Disclaimer
+Use this tool at your own risk. The author(s) and contributor(s) are not responsible for any damage, data loss, or system misconfiguration caused by its use. Always back up important data and test thoroughly in non-critical environments.

--- a/k8s_installer_app/app.py
+++ b/k8s_installer_app/app.py
@@ -1,0 +1,212 @@
+from flask import Flask, render_template, request, redirect, url_for, flash
+import paramiko
+import os
+
+app = Flask(__name__)
+# It's good practice to set a secret key for flash messages, though not strictly needed if not heavily used.
+app.secret_key = os.urandom(24)
+
+# Script paths
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+MASTER_SCRIPT_PATH = os.path.join(BASE_DIR, 'scripts', 'master_install.sh')
+WORKER_SCRIPT_PATH = os.path.join(BASE_DIR, 'scripts', 'worker_install.sh')
+
+
+def ssh_connect(ip, username, password):
+    """Establishes an SSH connection to the server."""
+    try:
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        # Increased timeout for potentially slower connections during setup
+        client.connect(ip, username=username, password=password, timeout=10)
+        print(f"Successfully connected to {ip}")
+        return client
+    except Exception as e:
+        print(f"Error connecting to {ip}: {e}")
+        return None
+
+def ssh_execute_command(client, command):
+    """Executes a command on the remote server via SSH."""
+    try:
+        # Set a timeout for command execution, e.g., 15 minutes for long install scripts
+        # The channel itself can have a timeout, or exec_command can.
+        # Paramiko's exec_command timeout is for establishing the channel, not the command itself.
+        # For long-running commands, we need to handle the stdout/stderr reading carefully.
+        stdin, stdout, stderr = client.exec_command(command, timeout=900)
+
+        # Reading stdout/stderr can block if the command produces a lot of output
+        # or if it doesn't close the streams.
+        stdout_output = stdout.read().decode('utf-8', errors='ignore')
+        stderr_output = stderr.read().decode('utf-8', errors='ignore')
+        exit_status = stdout.channel.recv_exit_status() # Wait for command to finish
+
+        print(f"Command: {command}")
+        # Limit printing large outputs to console for brevity in server logs
+        print(f"Stdout (first 500 chars): {stdout_output[:500]}")
+        print(f"Stderr (first 500 chars): {stderr_output[:500]}")
+        print(f"Exit Status: {exit_status}")
+        return stdout_output, stderr_output, exit_status
+    except Exception as e:
+        print(f"Error executing command '{command}': {e}")
+        # Return the exception as stderr_output for more direct feedback
+        return None, str(e), -1
+
+def ssh_close_connection(client):
+    """Closes the SSH connection."""
+    if client:
+        client.close()
+        print("SSH connection closed.")
+
+@app.route('/')
+def index():
+    results = request.args.getlist('results') # Get results if redirected
+    return render_template('index.html', results=results)
+
+@app.route('/install', methods=['POST'])
+def install():
+    results = []
+
+    master_ip = request.form['master_ip']
+    master_username = request.form['master_username']
+    master_password = request.form['master_password']
+    worker_ips_str = request.form.get('worker_ips', '') # Use .get for safety
+    worker_username = request.form['worker_username']
+    worker_password = request.form['worker_password']
+
+    # Master Node Setup
+    results.append(f"Attempting to connect to master node: {master_ip}")
+    master_client = ssh_connect(master_ip, master_username, master_password)
+
+    if master_client is None:
+        results.append(f"Failed to connect to master node: {master_ip}")
+        return render_template('index.html', results=results)
+
+    results.append(f"Successfully connected to master node: {master_ip}")
+
+    try:
+        sftp = master_client.open_sftp()
+        sftp.put(MASTER_SCRIPT_PATH, '/tmp/master_install.sh')
+        sftp.close()
+        results.append("Uploaded master_install.sh to master.")
+
+        _stdout_val, _stderr_val, chmod_status = ssh_execute_command(master_client, 'chmod +x /tmp/master_install.sh')
+        if chmod_status != 0:
+            results.append(f"Failed to chmod script on master: {_stderr_val}")
+            ssh_close_connection(master_client)
+            return render_template('index.html', results=results)
+        results.append("Made master_install.sh executable on master.")
+
+        results.append("Executing master_install.sh on master... This may take a while (up to 15 mins).")
+        master_stdout, master_stderr, master_exit_status = ssh_execute_command(master_client, 'sudo /tmp/master_install.sh')
+
+        results.append(f"Master script stdout:\n{master_stdout}")
+        results.append(f"Master script stderr:\n{master_stderr}")
+
+        if master_exit_status != 0:
+            results.append(f"Master script execution failed with exit status: {master_exit_status}")
+            ssh_close_connection(master_client)
+            return render_template('index.html', results=results)
+
+        results.append("Master script executed successfully.")
+
+        kubeadm_join_command = ""
+        if master_stdout: # Ensure master_stdout is not None
+            for line in master_stdout.splitlines():
+                if 'kubeadm join' in line and '--token' in line:
+                    kubeadm_join_command = line.strip() # Found the line
+                    # Often the command is split over multiple lines, let's try to get the next line too if it starts with spaces
+                    current_index = master_stdout.splitlines().index(line)
+                    if current_index + 1 < len(master_stdout.splitlines()):
+                        next_line = master_stdout.splitlines()[current_index+1].strip()
+                        if next_line.startswith('--discovery-token-ca-cert-hash'): # Characteristic of the next line
+                             kubeadm_join_command += " " + next_line
+                    break
+
+        if not kubeadm_join_command:
+            results.append("ERROR: Could not find 'kubeadm join' command in master script output. Please check the master logs.")
+            # Try to get it via command if master setup seemed to complete
+            results.append("Attempting to retrieve join command directly...")
+            join_cmd_stdout, join_cmd_stderr, join_cmd_status = ssh_execute_command(master_client, "sudo kubeadm token create --print-join-command")
+            if join_cmd_status == 0 and join_cmd_stdout.strip():
+                kubeadm_join_command = join_cmd_stdout.strip()
+                results.append(f"Successfully retrieved join command: {kubeadm_join_command}")
+            else:
+                results.append(f"Failed to retrieve join command directly. Stdout: {join_cmd_stdout}, Stderr: {join_cmd_stderr}")
+                ssh_close_connection(master_client)
+                return render_template('index.html', results=results)
+
+        results.append(f"Extracted/Retrieved join command: {kubeadm_join_command}")
+
+    except Exception as e:
+        results.append(f"An error occurred during master node setup: {str(e)}")
+        ssh_close_connection(master_client)
+        return render_template('index.html', results=results)
+    finally:
+        # Close master client if it hasn't been closed due to an error already
+        # However, if we successfully got the join command, we need it open for workers if master == worker.
+        # For now, let's close it here. If master is also a worker, it will be reconnected.
+        if master_client: # Check if it's still a valid client object
+             ssh_close_connection(master_client)
+
+
+    # Worker Node Setup
+    worker_ip_list = [ip.strip() for ip in worker_ips_str.split(',') if ip.strip()]
+    if not worker_ip_list and not kubeadm_join_command:
+        results.append("No worker IPs provided and no join command extracted. Assuming single-node cluster or manual worker addition.")
+    elif not worker_ip_list and kubeadm_join_command:
+        results.append("Master node setup complete. No worker IPs provided for automated setup.")
+    elif not kubeadm_join_command: # Should have been caught earlier
+        results.append("Critical error: No join command available for worker nodes.")
+        return render_template('index.html', results=results)
+
+
+    for worker_ip in worker_ip_list:
+        results.append(f"--- Processing Worker Node: {worker_ip} ---")
+        results.append(f"Attempting to connect to worker node: {worker_ip}")
+        worker_client = ssh_connect(worker_ip, worker_username, worker_password)
+
+        if worker_client is None:
+            results.append(f"Failed to connect to worker node: {worker_ip}")
+            continue
+
+        results.append(f"Successfully connected to worker node: {worker_ip}")
+
+        try:
+            sftp_worker = worker_client.open_sftp()
+            sftp_worker.put(WORKER_SCRIPT_PATH, '/tmp/worker_install.sh')
+            sftp_worker.close()
+            results.append(f"Uploaded worker_install.sh to {worker_ip}.")
+
+            _stdout_val, _stderr_val, chmod_status_worker = ssh_execute_command(worker_client, 'chmod +x /tmp/worker_install.sh')
+            if chmod_status_worker != 0:
+                results.append(f"Failed to chmod script on {worker_ip}: {_stderr_val}")
+                ssh_close_connection(worker_client)
+                continue
+            results.append(f"Made worker_install.sh executable on {worker_ip}.")
+
+            results.append(f"Executing worker_install.sh on {worker_ip}... This may take a while.")
+            # Ensure the join command is properly quoted when passed to the script
+            worker_command = f"sudo /tmp/worker_install.sh \"{kubeadm_join_command}\""
+
+            worker_stdout, worker_stderr, worker_exit_status = ssh_execute_command(worker_client, worker_command)
+
+            results.append(f"Worker {worker_ip} script stdout:\n{worker_stdout}")
+            results.append(f"Worker {worker_ip} script stderr:\n{worker_stderr}")
+
+            if worker_exit_status != 0:
+                results.append(f"Worker {worker_ip} script execution failed with exit status: {worker_exit_status}")
+            else:
+                results.append(f"Worker {worker_ip} script executed successfully.")
+
+        except Exception as e:
+            results.append(f"An error occurred during worker node {worker_ip} setup: {str(e)}")
+        finally:
+            if worker_client:
+                ssh_close_connection(worker_client)
+        results.append(f"--- Finished Processing Worker Node: {worker_ip} ---")
+
+    results.append("All operations completed. Check status above.")
+    return render_template('index.html', results=results)
+
+if __name__ == '__main__':
+    app.run(debug=True, host='0.0.0.0', port=5000)

--- a/k8s_installer_app/scripts/master_install.sh
+++ b/k8s_installer_app/scripts/master_install.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -e
+set -x
+
+# Update package lists
+sudo apt-get update -y
+
+# Install prerequisite packages
+sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common
+
+# Disable swap
+sudo swapoff -a
+# Comment out swap entries in /etc/fstab
+# Use a temporary file to avoid issues with sed directly modifying /etc/fstab in some environments
+sudo cp /etc/fstab /etc/fstab.bak
+cat /etc/fstab.bak | grep -v 'swap' | sudo tee /etc/fstab > /dev/null
+
+# Install container runtime (containerd)
+sudo apt-get install -y containerd
+sudo mkdir -p /etc/containerd
+sudo containerd config default | sudo tee /etc/containerd/config.toml
+sudo sed -i 's/SystemdCgroup = false/SystemdCgroup = true/g' /etc/containerd/config.toml
+sudo systemctl restart containerd
+sudo systemctl enable containerd
+
+# Add Kubernetes APT repository and key
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+sudo apt-add-repository "deb http://apt.kubernetes.io/ kubernetes-xenial main"
+
+# Install Kubernetes components
+sudo apt-get update -y
+sudo apt-get install -y kubelet kubeadm kubectl
+
+# Mark Kubernetes components to hold their version
+sudo apt-mark hold kubelet kubeadm kubectl
+
+# Enable and start kubelet
+sudo systemctl enable kubelet
+# Note: Kubelet might enter a crashloop until the cluster is initialized. This is expected.
+# We will start it after kubeadm init or let kubeadm manage its start.
+# For now, ensuring it's enabled is key. Kubeadm will start it.
+
+echo "Kubelet enabled. Kubeadm will start it during init."
+
+# Initialize Kubernetes cluster
+# Using a common CIDR for Flannel. Can be parameterized later.
+# Ensure the node IP is correctly identified by kubeadm or specify it if needed.
+# Adding --ignore-preflight-errors=Swap for robustness in environments where swapoff might not be immediate
+sudo kubeadm init --pod-network-cidr=10.244.0.0/16 --ignore-preflight-errors=Swap
+
+# Set up kubeconfig for the user
+mkdir -p $HOME/.kube
+sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+sudo chown $(id -u):$(id -g) $HOME/.kube/config
+
+# Install a Pod Network Add-on (Flannel)
+# This requires kubectl to be configured, so it runs after setting up kubeconfig.
+echo "Applying Flannel CNI..."
+kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
+
+echo "Master node installation script completed."
+
+# Output the kubeadm join command
+echo "To add worker nodes, use the following command:"
+sudo kubeadm token create --print-join-command

--- a/k8s_installer_app/scripts/worker_install.sh
+++ b/k8s_installer_app/scripts/worker_install.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -e
+set -x
+
+# Check if the join command is provided
+if [ -z "$1" ]; then
+    echo "Error: Kubeadm join command not provided."
+    echo "Usage: $0 \"<kubeadm_join_command>\""
+    exit 1
+fi
+
+JOIN_COMMAND=$1
+
+# Update package lists
+sudo apt-get update -y
+
+# Install prerequisite packages
+sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common
+
+# Disable swap
+sudo swapoff -a
+# Comment out swap entries in /etc/fstab
+sudo cp /etc/fstab /etc/fstab.bak
+cat /etc/fstab.bak | grep -v 'swap' | sudo tee /etc/fstab > /dev/null
+
+# Install container runtime (containerd)
+sudo apt-get install -y containerd
+sudo mkdir -p /etc/containerd
+sudo containerd config default | sudo tee /etc/containerd/config.toml
+sudo sed -i 's/SystemdCgroup = false/SystemdCgroup = true/g' /etc/containerd/config.toml
+sudo systemctl restart containerd
+sudo systemctl enable containerd
+
+# Add Kubernetes APT repository and key
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+sudo apt-add-repository "deb http://apt.kubernetes.io/ kubernetes-xenial main"
+
+# Install Kubernetes components (kubelet and kubeadm)
+# kubectl is not strictly required on worker nodes but can be useful for debugging.
+# For minimal setup, it can be omitted.
+sudo apt-get update -y
+sudo apt-get install -y kubelet kubeadm # kubectl
+
+# Mark Kubernetes components to hold their version
+sudo apt-mark hold kubelet kubeadm # kubectl
+
+# Enable and start kubelet
+sudo systemctl enable kubelet
+# Kubelet will be started by kubeadm join or will restart after successful join.
+echo "Kubelet enabled. Kubeadm will manage its state during join."
+
+# Execute the kubeadm join command
+echo "Attempting to join the Kubernetes cluster..."
+# Adding --ignore-preflight-errors=Swap for robustness
+# Ensure the JOIN_COMMAND is quoted if it contains spaces, although it should be passed as a single arg.
+sudo bash -c "$JOIN_COMMAND --ignore-preflight-errors=Swap"
+
+echo "Worker node installation script completed."
+echo "Node should now be part of the Kubernetes cluster. Verify on the master node with 'kubectl get nodes'."

--- a/k8s_installer_app/templates/index.html
+++ b/k8s_installer_app/templates/index.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Kubernetes Installer</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; background-color: #f4f4f4; color: #333; }
+        h1, h2 { color: #0056b3; }
+        form { background-color: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+        label { display: block; margin-top: 10px; font-weight: bold; }
+        input[type="text"], input[type="password"], textarea {
+            width: calc(100% - 22px); padding: 10px; margin-top: 5px; border: 1px solid #ddd; border-radius: 4px; box-sizing: border-box;
+        }
+        textarea { resize: vertical; }
+        input[type="submit"] {
+            background-color: #0056b3; color: white; padding: 10px 20px; border: none; border-radius: 4px; cursor: pointer; font-size: 16px; margin-top: 20px;
+        }
+        input[type="submit"]:hover { background-color: #004494; }
+        .results-container { margin-top: 30px; background-color: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+        .results-container h2 { margin-top: 0; }
+        .results-container ul { list-style-type: none; padding: 0; }
+        .results-container li { background-color: #e9ecef; margin-bottom: 8px; padding: 10px; border-radius: 4px; font-size: 0.9em; }
+        .results-container li pre { white-space: pre-wrap; word-wrap: break-word; margin: 0; font-family: "Courier New", Courier, monospace; }
+        .security-warning { color: red; border: 1px solid red; padding: 10px; margin-bottom: 15px; background-color: #ffebeb; border-radius: 4px;}
+    </style>
+</head>
+<body>
+    <h1>Kubernetes Installer</h1>
+
+    <div class="security-warning">
+        <strong>Security Warning:</strong> This tool uses password-based SSH authentication which is not recommended for production environments.
+        It is intended for experimental and educational purposes only.
+        Ensure you are using it in a secure, isolated environment.
+        Consider using SSH key-based authentication for better security. Data is transmitted to the server, and scripts are executed with sudo privileges.
+    </div>
+
+    {% if results %}
+    <div class="results-container">
+        <h2>Installation Status:</h2>
+    <meta charset="UTF-8">
+    <title>Kubernetes Installer</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; background-color: #f4f4f4; color: #333; }
+        h1, h2 { color: #0056b3; }
+        form { background-color: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+        label { display: block; margin-top: 10px; font-weight: bold; }
+        input[type="text"], input[type="password"], textarea {
+            width: calc(100% - 22px); padding: 10px; margin-top: 5px; border: 1px solid #ddd; border-radius: 4px; box-sizing: border-box;
+        }
+        textarea { resize: vertical; }
+        input[type="submit"] {
+            background-color: #0056b3; color: white; padding: 10px 20px; border: none; border-radius: 4px; cursor: pointer; font-size: 16px; margin-top: 20px;
+        }
+        input[type="submit"]:hover { background-color: #004494; }
+        .results-container { margin-top: 30px; background-color: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+        .results-container h2 { margin-top: 0; }
+        .results-container ul { list-style-type: none; padding: 0; }
+        .results-container li { background-color: #e9ecef; margin-bottom: 8px; padding: 10px; border-radius: 4px; font-size: 0.9em; }
+        .results-container li pre { white-space: pre-wrap; word-wrap: break-word; margin: 0; font-family: "Courier New", Courier, monospace; }
+        .security-warning { color: red; border: 1px solid red; padding: 10px; margin-bottom: 15px; background-color: #ffebeb; border-radius: 4px;}
+    </style>
+</head>
+<body>
+    <h1>Kubernetes Installer</h1>
+
+    <div class="security-warning">
+        <strong>Security Warning:</strong> This tool uses password-based SSH authentication which is not recommended for production environments.
+        It is intended for experimental and educational purposes only.
+        Ensure you are using it in a secure, isolated environment.
+        Consider using SSH key-based authentication for better security. Data is transmitted to the server, and scripts are executed with sudo privileges.
+    </div>
+
+    {% if results %}
+    <div class="results-container">
+        <h2>Installation Status:</h2>
+        <ul>
+            {% for result in results %}
+            <li><pre>{{ result }}</pre></li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
+
+    <form action="/install" method="post">
+        <h2>Master Node Configuration</h2>
+        <label for="master_ip">Master Node IP:</label>
+        <input type="text" id="master_ip" name="master_ip" required>
+
+        <label for="master_username">Master Node Username:</label>
+        <input type="text" id="master_username" name="master_username" required>
+
+        <label for="master_password">Master Node Password:</label>
+        <input type="password" id="master_password" name="master_password" required>
+
+        <h2>Worker Nodes Configuration</h2>
+        <label for="worker_ips">Worker Node IPs (comma-separated, e.g., 192.168.1.101,192.168.1.102):</label>
+        <textarea id="worker_ips" name="worker_ips" rows="3" placeholder="Leave blank if no dedicated workers or if master is also a worker and no other workers."></textarea>
+
+        <label for="worker_username">Worker Node Username (for all workers):</label>
+        <input type="text" id="worker_username" name="worker_username">
+
+        <label for="worker_password">Worker Node Password (for all workers):</label>
+        <input type="password" id="worker_password" name="worker_password">
+        <p style="font-size: 0.8em; color: #666;">Note: If worker details are left blank and worker IPs are provided, master node credentials will be attempted for workers. This is not recommended for production.</p>
+
+
+        <input type="submit" value="Install Kubernetes">
+    </form>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+paramiko


### PR DESCRIPTION
This commit introduces a Flask-based web application that allows you to install Kubernetes on a set of servers (one master, multiple worker nodes) via SSH.

Key features:
- Web UI to input server credentials (IP, username, password).
- Automated installation of Kubernetes (kubeadm, kubelet, kubectl) and containerd on master and worker nodes using uploaded shell scripts.
- Initializes the master node using `kubeadm init`.
- Joins worker nodes to the cluster using the `kubeadm join` command obtained from the master.
- Installs Flannel as the CNI plugin.
- Provides real-time feedback of the installation process in the web UI, including script outputs and error messages.
- Includes error handling for SSH connections and script executions.
- Displays security warnings regarding password-based SSH and the experimental nature of the tool.

The application structure includes:
- `app.py`: Main Flask application with SSH logic and installation orchestration.
- `templates/index.html`: Web interface for your input and results display.
- `scripts/master_install.sh`: Script for Kubernetes master node setup.
- `scripts/worker_install.sh`: Script for Kubernetes worker node setup.
- `requirements.txt`: Python dependencies (Flask, Paramiko).
- `README.md`: Detailed documentation on setup, usage, and security.